### PR TITLE
refactor: change sequence_number to sequence_position

### DIFF
--- a/packages/event-store-postgres/src/eventHandling/HandlerCatchup.tests.ts
+++ b/packages/event-store-postgres/src/eventHandling/HandlerCatchup.tests.ts
@@ -34,7 +34,7 @@ describe("UpdatePostgresHandlers tests", () => {
         await client.query("COMMIT")
         client.release()
         await pool.query("TRUNCATE table events")
-        await pool.query("ALTER SEQUENCE events_sequence_number_seq RESTART WITH 1")
+        await pool.query("ALTER SEQUENCE events_sequence_position_seq RESTART WITH 1")
     })
 
     afterAll(async () => {

--- a/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
+++ b/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
@@ -41,7 +41,7 @@ export class HandlerCatchup {
         try {
             const selectResult = await this.client.query(
                 `
-                SELECT handler_id, last_sequence_number
+                SELECT handler_id, last_sequence_position
                 FROM ${tableName}
                 WHERE handler_id = ANY($1::text[])
                 FOR UPDATE NOWAIT;`,
@@ -51,7 +51,7 @@ export class HandlerCatchup {
             const result = Object.keys(handlers).reduce((acc, handlerId) => {
                 const sequencePosition = selectResult.rows.find(
                     row => row.handler_id === handlerId
-                )?.last_sequence_number
+                )?.last_sequence_position
                 if (sequencePosition !== undefined) {
                     return {
                         ...acc,
@@ -85,8 +85,8 @@ export class HandlerCatchup {
         ])
 
         const updateQuery = `
-            UPDATE ${this.tableName} SET last_sequence_number = v.last_sequence_number
-            FROM (VALUES ${updateValues}) AS v(handler_id, last_sequence_number)
+            UPDATE ${this.tableName} SET last_sequence_position = v.last_sequence_position
+            FROM (VALUES ${updateValues}) AS v(handler_id, last_sequence_position)
             WHERE ${this.tableName}.handler_id = v.handler_id;`
 
         await this.client.query(updateQuery, updateParams)

--- a/packages/event-store-postgres/src/eventHandling/ensureHandlersInstalled.ts
+++ b/packages/event-store-postgres/src/eventHandling/ensureHandlersInstalled.ts
@@ -4,12 +4,12 @@ export const ensureHandlersInstalled = async (pool: Pool | PoolClient, handlerId
     await pool.query(`
         CREATE TABLE IF NOT EXISTS ${tableName} (
             handler_id TEXT PRIMARY KEY,
-            last_sequence_number BIGINT
+            last_sequence_position BIGINT
         );`)
 
     await pool.query(
         `
-        INSERT INTO ${tableName} (handler_id, last_sequence_number)
+        INSERT INTO ${tableName} (handler_id, last_sequence_position)
         SELECT handler_id, 0
         FROM unnest($1::text[]) handler_id
         ON CONFLICT (handler_id) DO NOTHING

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.append.tests.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.append.tests.ts
@@ -55,7 +55,7 @@ describe("postgresEventStore.append", () => {
         await client.query("COMMIT")
         client.release()
         await pool.query("TRUNCATE table events")
-        await pool.query("ALTER SEQUENCE events_sequence_number_seq RESTART WITH 1")
+        await pool.query("ALTER SEQUENCE events_sequence_position_seq RESTART WITH 1")
     })
 
     afterAll(async () => {
@@ -180,7 +180,7 @@ describe("postgresEventStore.append", () => {
                 expectedCeiling: SequencePosition.create(1)
             }
 
-            // First append should pass and set sequence_number to 2
+            // First append should pass and set sequence_position to 2
             await eventStore.append(new EventType1(), appendCondition)
             await eventStore.append(new EventType2())
 

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.query.tests.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.query.tests.ts
@@ -48,7 +48,7 @@ describe("memoryEventStore.query", () => {
         await client.query("COMMIT")
         client.release()
         await pool.query("TRUNCATE table events")
-        await pool.query("ALTER SEQUENCE events_sequence_number_seq RESTART WITH 1")
+        await pool.query("ALTER SEQUENCE events_sequence_position_seq RESTART WITH 1")
     })
 
     afterAll(async () => {

--- a/packages/event-store-postgres/src/eventStore/appendCommand.ts
+++ b/packages/event-store-postgres/src/eventStore/appendCommand.ts
@@ -38,7 +38,7 @@ export const appendSql = (
                             FROM ${tableName}
                             WHERE type IN (${(c.eventTypes ?? []).map(t => params.add(t)).join(", ")})
                             AND tags @> ${params.add(c.tags?.values ?? [])}::text[]
-                            AND sequence_number > ${maxSeqNoParam}::bigint
+                            AND sequence_position > ${maxSeqNoParam}::bigint
                         `
                     )
                     .join(" UNION ALL ")}
@@ -55,10 +55,10 @@ export const appendSql = (
         SELECT type, data, metadata, tags
         FROM new_events
         ${filterClause()}
-        RETURNING sequence_number, type, data, tags, "timestamp"
+        RETURNING sequence_position, type, data, tags, "timestamp"
       )
       SELECT
-        sequence_number,
+        sequence_position,
         type,
         data,
         tags,

--- a/packages/event-store-postgres/src/eventStore/ensureInstalled.ts
+++ b/packages/event-store-postgres/src/eventStore/ensureInstalled.ts
@@ -3,7 +3,7 @@ import { Pool, PoolClient } from "pg"
 export const ensureInstalled = async (pool: Pool | PoolClient, tableName: string) => {
     await pool.query(`
         CREATE TABLE IF NOT EXISTS ${tableName} (
-          sequence_number BIGSERIAL PRIMARY KEY,
+          sequence_position BIGSERIAL PRIMARY KEY,
           type TEXT NOT NULL,
           data JSONB NOT NULL,
           metadata JSONB NOT NULL,
@@ -11,8 +11,8 @@ export const ensureInstalled = async (pool: Pool | PoolClient, tableName: string
           "timestamp" TIMESTAMPTZ DEFAULT now()
         );
 
-        CREATE INDEX IF NOT EXISTS ${tableName}_sequence_number_idx 
-        ON ${tableName}(sequence_number);
+        CREATE INDEX IF NOT EXISTS ${tableName}_sequence_position_idx 
+        ON ${tableName}(sequence_position);
         CREATE INDEX IF NOT EXISTS ${tableName}_type_idx 
         ON ${tableName}(type);
         CREATE INDEX IF NOT EXISTS ${tableName}_tags_idx 

--- a/packages/event-store-postgres/src/eventStore/utils.ts
+++ b/packages/event-store-postgres/src/eventStore/utils.ts
@@ -13,7 +13,7 @@ export type DbReadEvent = {
     metadata: unknown
     tags: string[]
     timestamp: string
-    sequence_number: string
+    sequence_position: string
 }
 
 export const dbEventConverter = {
@@ -24,7 +24,7 @@ export const dbEventConverter = {
         tags: [...dcbEvent.tags.values]
     }),
     fromDb: (dbEvent: DbReadEvent): EventEnvelope => ({
-        sequencePosition: SequencePosition.create(parseInt(dbEvent.sequence_number)),
+        sequencePosition: SequencePosition.create(parseInt(dbEvent.sequence_position)),
         timestamp: Timestamp.create(dbEvent.timestamp),
         event: {
             type: dbEvent.type,


### PR DESCRIPTION
simple change to refactor references to sequence_number in database and code.

NOTE - unsure about the publishing process and/or bumping the cross dependency "@dcb-es/event-store": "^5.0.0", in postgres-event-store

