### PR TITLE
feat: expose register handlers

### DIFF
--- a/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
+++ b/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
@@ -1,6 +1,6 @@
 import { EventHandler, EventStore, Query, SequencePosition, Tags } from "@dcb-es/event-store"
 import { Pool, PoolClient } from "pg"
-import { ensureHandlersInstalled } from "./ensureHandlersInstalled"
+import { ensureHandlersInstalled, registerhandlers } from "./ensureHandlersInstalled"
 
 export type HandlerCheckPoints = Record<string, SequencePosition>
 
@@ -16,6 +16,10 @@ export class HandlerCatchup {
 
     async ensureInstalled(handlerIds: string[]): Promise<void> {
         await ensureHandlersInstalled(this.client, handlerIds, this.tableName)
+    }
+
+    async registerHandlers(handlerIds: string[]): Promise<void> {
+        await registerhandlers(this.client, handlerIds, this.tableName)
     }
 
     async catchupHandlers(

--- a/packages/event-store-postgres/src/eventHandling/ensureHandlersInstalled.ts
+++ b/packages/event-store-postgres/src/eventHandling/ensureHandlersInstalled.ts
@@ -7,6 +7,10 @@ export const ensureHandlersInstalled = async (pool: Pool | PoolClient, handlerId
             last_sequence_position BIGINT
         );`)
 
+    await registerhandlers(pool, handlerIds, tableName)
+}
+
+export const registerhandlers = async (pool: Pool | PoolClient, handlerIds: string[], tableName: string) => {
     await pool.query(
         `
         INSERT INTO ${tableName} (handler_id, last_sequence_position)


### PR DESCRIPTION
This PR exposes a method in postgres event handler lib so that consuming code can use it to register handlers without running the create table query - not super important since it has `IF NOT EXISTS` but this is a little neater